### PR TITLE
Update the repository to be compatible with 0.19.1 DBT version

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,6 +1,6 @@
 name: 'dbt_extend'
 version: '0.2.4'
-
+config-version: 2
 target-path: "target"
 clean-targets: ["target", "dbt_modules"]
 macro-paths: ["macros"]

--- a/models/example.sql
+++ b/models/example.sql
@@ -4,9 +4,4 @@
     )
 }}
 select 
-    {{ dbt_extend.get_local_time() }} as currently,
-    {{ dbt_extend.get_local_date() }} as today,
-    {{ dbt_extend.yesterday() }} as today,
-    {{ dbt_date.tomorrow() }} as tomorrow,
-    {{ dbt_extend.convert_timezone('currently') }} as the_converted_time,
-    {{ dbt_extend.convert_timezone('today') }} as the_converted_date
+    {{ dbt_date.tomorrow() }} as tomorrow

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: fishtown-analytics/dbt_utils
-    version: [">=0.2.0", "<0.3.0"]    
+    version: [">=0.6.0", "<=0.6.4"]    


### PR DESCRIPTION
* Added config version 2 to the dbt_project.yml as required by the DBT version.
* Updated the example model to not call dbt-extend date macros as it gives warning.

