### PR TITLE
DATA2-689 Get ready for DBT 1.0

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -2,11 +2,11 @@ name: 'dbt_extend'
 version: '0.2.4'
 config-version: 2
 target-path: "target"
-clean-targets: ["target", "dbt_modules"]
+clean-targets: ["target", "dbt_packages"]
 macro-paths: ["macros"]
 log-path: "logs"
 
-require-dbt-version: ">=0.13.0"
+require-dbt-version: [">=1.0.0", "<2.0.0"]
 profile: dw
 quoting:
     identifier: false

--- a/macros/schema_tests/equal_expression.sql
+++ b/macros/schema_tests/equal_expression.sql
@@ -52,6 +52,6 @@
                 a.col_{{ i }} = b.col_{{ i }} {% if not loop.last %}and{% endif %}
             {% endfor -%}
     )
-    select count(*) from final where exp_diff > {{ tol }}
+    select count(*) from final where exp_diff > {{ tol }} having count(*) > 0
 
 {%- endmacro -%}

--- a/macros/schema_tests/frequency.sql
+++ b/macros/schema_tests/frequency.sql
@@ -71,5 +71,5 @@ final as
         left outer join
         model_data f on d.date_{{date_part}} = f.date_{{date_part}}
 )
-select count(*) from final where row_cnt = 0
+select count(*) from final where row_cnt = 0 having count(*) > 0
 {%- endmacro -%}

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: dbt-labs/dbt_utils
-    version: ">=0.7.4"  
+    version: [">=0.8.0", "<0.9.0"]

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: dbt-labs/dbt_utils
-    version: [">=0.6.0", "<=0.6.4"]    
+    version: ">=0.7.4"  

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
-  - package: fishtown-analytics/dbt_utils
+  - package: dbt-labs/dbt_utils
     version: [">=0.6.0", "<=0.6.4"]    


### PR DESCRIPTION
* Update the project to accept dbt 1.0
* Update the project to refer to dbt-labs/dbt_utils. The version should be ">=0.7.4"
* Updated equal_expression to check for count() > 0 as snowflake returns a row with 0 count when condition doesn't satisfies and dbt has started giving error for such passed cases as well. The Count(1) returns a row with the count. If no row qualifies, it still gives 0 value. I think the handling of error in dbt test has changed and it has started giving the 2nd scenario as error. Appending the count() > 0 ensures that it fails only if the check gives count of > 0

```
	SELECT 1 WHERE 1=0 -- This statement returns 0 rows
	SELECT COUNT(1) WHERE 1=0 -- This statement returns 1 row with count of 0
```